### PR TITLE
Teacher sign up logic

### DIFF
--- a/backend/src/domain/src/teacher/Teacher.ts
+++ b/backend/src/domain/src/teacher/Teacher.ts
@@ -1,6 +1,6 @@
 import { Question } from '../question/Question';
 import { TeachingArea } from '../../../../../shared/enum';
-import { TeacherInterface } from '../../../../../shared/interfaces';
+import { TeacherInterface, Credential } from '../../../../../shared/interfaces';
 export class Teacher implements TeacherInterface {
   private readonly teacherId: number;
 

--- a/backend/src/domain/src/teacher/dto/createTeacher.ts
+++ b/backend/src/domain/src/teacher/dto/createTeacher.ts
@@ -1,6 +1,7 @@
 import { IsEmail, IsNumber, IsString, IsStrongPassword } from 'class-validator';
 import { Question } from '../../question/Question';
 import { TeachingArea } from '../../../../../../shared/enum';
+import { Credential } from '../../../../../../shared/interfaces';
 
 export class CreateTeacherDto {
   @IsString()

--- a/backend/src/domain/src/teacher/teacherController.ts
+++ b/backend/src/domain/src/teacher/teacherController.ts
@@ -3,10 +3,11 @@ import {
   Get,
   Post,
   Body,
-  // BadRequestException,
+  BadRequestException,
   // NotFoundException,
 } from '@nestjs/common';
-
+import { Teacher } from './Teacher';
+import { CreateTeacherDto } from './dto';
 import { TeacherLoginDto } from './dto/loginTeacher';
 import { TeacherService } from './teacherService';
 @Controller('teacher')
@@ -35,28 +36,18 @@ export class TeacherController {
     return { message: 'Login successful', teacher };
   }
 
-  // @Post('sign-up')
-  // async create(@Body() createTeacherDto: CreateTeacherDto): Promise<Teacher> {
-  //   const existingTeacher = this.teacherService.findById(
-  //     createTeacherDto.teacherId,
-  //   );
-  //   if (existingTeacher) {
-  //     throw new BadRequestException('Account already exists');
-  //   }
-  //   return this.teacherService.create(createTeacherDto);
-  // }
+  @Post('sign-up')
+  async create(@Body() createTeacherDto: CreateTeacherDto): Promise<Teacher> {
+    const existingTeacher = await this.teacherService.findByEmail(
+      createTeacherDto.email,
+    );
 
-  // @Post('login')
-  // async login(@Body() loginTeacherDto: TeacherLoginDto): Promise<Teacher> {
-  //   const teacher = this.teacherService.findByEmailAndPassword(
-  //     loginTeacherDto.email,
-  //     loginTeacherDto.password,
-  //   );
-  //   if (!teacher) {
-  //     throw new NotFoundException('Teacher not found');
-  //   }
-  //   return teacher;
-  // }
+    if (existingTeacher) {
+      throw new BadRequestException('Account already exists');
+    }
+
+    return this.teacherService.create(createTeacherDto);
+  }
 
   // @Get()
   // async findAll(): Promise<Teacher[]> {

--- a/backend/src/domain/src/teacher/teacherService.ts
+++ b/backend/src/domain/src/teacher/teacherService.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Teacher } from './Teacher';
 import { TeachingArea } from '../../../../../shared/enum';
+import { CreateTeacherDto } from './dto/createTeacher';
 
 @Injectable()
 export class TeacherService {
@@ -36,5 +37,23 @@ export class TeacherService {
       throw new NotFoundException('Invalid credentials');
     }
     return teacher;
+  }
+
+  async findByEmail(email: string): Promise<Teacher | undefined> {
+    return this.teachers.find((t) => t.email === email);
+  }
+
+  async create(createTeacherDto: CreateTeacherDto): Promise<Teacher> {
+    const newTeacher = new Teacher(
+      createTeacherDto.name,
+      createTeacherDto.email,
+      createTeacherDto.password,
+      createTeacherDto.credentials,
+      createTeacherDto.teachingArea,
+      createTeacherDto.score || 0,
+      createTeacherDto.answeredQuestions || [],
+    );
+    this.teachers.push(newTeacher);
+    return newTeacher;
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,7 +5,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
     origin: 'http://localhost:8080',
-    methods: 'GET,POST,PUT,DELETE',
+    methods: 'GET,POST,PUT,DELETE,OPTIONS',
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   const port = 3000;

--- a/shared/interfaces.ts
+++ b/shared/interfaces.ts
@@ -34,3 +34,14 @@ export interface QuestionInterface {
   answers: Answer[];
   answeredBy?: Teacher;
 }
+
+export interface Credential {
+  id: string;
+  name: string;
+  type: string;
+  url: string;
+  uploadedAt: Date;
+  isVerified: boolean;
+  verifiedAt?: Date;
+  remarks?: string;
+}

--- a/ui/src/components/Teacher/pages/TeacherLogin/TeacherLogin.tsx
+++ b/ui/src/components/Teacher/pages/TeacherLogin/TeacherLogin.tsx
@@ -2,7 +2,6 @@ import {
   FormControl,
   Input,
   Box,
-  Button,
   Container,
   Heading,
   SimpleGrid,

--- a/ui/src/components/Teacher/pages/TeacherSignUp/TeacherSignUp.test.tsx
+++ b/ui/src/components/Teacher/pages/TeacherSignUp/TeacherSignUp.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { WrapperTestingLibrary } from '../../../helpers/WrapperTestingLibrary';
+import TeacherSignUp from './TeacherSignUp';
+import { usePostCreateTeacher } from '../../../../hooks/usePostCreateTeacher';
+
+// Mock the custom hook to control the behavior during tests
+jest.mock('../../../../hooks/usePostCreateTeacher', () => ({
+  usePostCreateTeacher: jest.fn(),
+  mutate: jest.fn()
+}));
+
+const renderComponent = () =>
+  render(
+    <WrapperTestingLibrary>
+      <ChakraProvider>
+        <TeacherSignUp />
+      </ChakraProvider>
+    </WrapperTestingLibrary>
+  );
+
+describe('TeacherSignUp Component', () => {
+
+  beforeEach(() => {
+ const mockMutate = jest.fn();
+ (usePostCreateTeacher as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+    });
+  })
+  it('should render the account creation title', () => {
+    renderComponent();
+
+    expect(screen.getByText('Create your')).toBeInTheDocument();
+  });
+
+  it('should render input fields for name, email, password, and confirm password', () => {
+    renderComponent();
+
+    expect(screen.getByPlaceholderText(/First and last name/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Your best email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Confirm password/i)).toBeInTheDocument();
+  });
+
+  it('should render the file input for uploading a document', () => {
+    renderComponent();
+
+    expect(screen.getByText(/upload your license legal document/i)).toBeInTheDocument();
+  });
+
+  it('should render the submit button', () => {
+    renderComponent();
+
+    const submitButton = screen.getByRole('button', { name: /Submit/i });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toHaveTextContent('Submit');
+  });
+
+  it('should call the createTeacher function when the form is submitted with valid data', async () => {
+    const mockCreateTeacher = jest.fn();
+    (usePostCreateTeacher as jest.Mock).mockReturnValue({ mutate: mockCreateTeacher });
+
+    renderComponent();
+
+    const nameInput = screen.getByPlaceholderText(/First and last name/i);
+    const emailInput = screen.getByPlaceholderText(/Your best email/i);
+    const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+    const passwordInput = passwordInputs[0];  // Password input
+    const confirmPasswordInput = passwordInputs[1];
+    const submitButton = screen.getByRole('button', { name: /Submit/i });
+
+    fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+    fireEvent.change(emailInput, { target: { value: 'john.doe@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } });
+
+     fireEvent.click(submitButton);
+
+
+    await waitFor(() => {
+      expect(mockCreateTeacher).toHaveBeenCalled();
+    });
+  });
+
+  it('should show validation error for password mismatch', async () => {
+    renderComponent();
+
+    const nameInput = screen.getByPlaceholderText(/First and last name/i);
+    const emailInput = screen.getByPlaceholderText(/Your best email/i);
+    const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+    const passwordInput = passwordInputs[0];
+    const confirmPasswordInput = passwordInputs[1];
+    const submitButton = screen.getByRole('button', { name: /Submit/i });
+
+    fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+    fireEvent.change(emailInput, { target: { value: 'john.doe@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password321' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Password mismatch/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/helpers/enum.ts
+++ b/ui/src/components/helpers/enum.ts
@@ -1,0 +1,9 @@
+export enum TeachingArea {
+  Portuguese = 'Portuguese',
+  Mathematics = 'Mathematics',
+  History = 'History',
+  Geography = 'Geography',
+  Sciences = 'Sciences',
+  Literature = 'Literature',
+  English = 'English',
+}

--- a/ui/src/components/helpers/interfaces.ts
+++ b/ui/src/components/helpers/interfaces.ts
@@ -1,17 +1,15 @@
 
 import { TeachingArea, Grade } from '@shared/enum'
-import { StudentInterface, TeacherInterface } from '@shared/interfaces';
-import FileUpload, { ConfirmedPassword } from '../helpers/utils';
+import { Credential, StudentInterface, TeacherInterface } from '@shared/interfaces';
+import { ConfirmedPassword } from '../helpers/utils';
 
 interface TeacherRegistry {
-  teacherId: string;
   name: string;
   email: string;
   password: string; 
   confirmPassword: string;
   teachingAreas: TeachingArea[];
-  credentials: typeof FileUpload;
-  error: {}
+  credentials: Credential;
 }
 
 interface StudentRegistry {

--- a/ui/src/hooks/usePostCreateTeacher.ts
+++ b/ui/src/hooks/usePostCreateTeacher.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { teacherSignUp } from '../services/TeacherService';
+import { TeachingArea } from '@shared/enum';
+
+/**
+ * Custom hook for creating a teacher.
+ * @param {object} options - Options for the mutation (e.g., onSuccess, onError).
+ */
+export const usePostCreateTeacher = (options = {}) => {
+  return useMutation({
+    mutationFn: (data: { name: string; email: string; password: string; confirmPassword: string, teachingAreas: TeachingArea[], credentials: Credential }) =>
+      teacherSignUp(data),
+    mutationKey: ['teacher', 'create'],
+    ...options,
+  });
+};

--- a/ui/src/services/TeacherService.ts
+++ b/ui/src/services/TeacherService.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '../config/axiosConfig'
-import { TeacherLoginInterface } from 'ui/src/components/helpers/interfaces';
+import { TeacherLoginInterface, TeacherRegistry } from 'ui/src/components/helpers/interfaces';
 
 export const fetchTeacherSignUp = async () => {
   const response = await axiosInstance.get('http://localhost:8080/teacher/sign-up');
@@ -13,5 +13,10 @@ export const fetchTeacherDashboard = async () => {
 
 export const teacherLogin = async (data: TeacherLoginInterface) => {
   const response = await axiosInstance.post('http://localhost:3000/teacher/login', data);
+  return response.data;
+};
+
+export const teacherSignUp = async (data: TeacherRegistry) => {
+  const response = await axiosInstance.post('http://localhost:3000/teacher/sign-up', data);
   return response.data;
 };


### PR DESCRIPTION
Backend:
- Adds POST endpoint for `sign-up` on TeacherController
- Adds create method on TeacherService
- CreateTeacherDTO

Shared
- Adds new shared interface `Credential`, adopted on both domain dtos and frontend interfaces

Frontend
- Implements `usePostCreateTeacher` hook 
- `createTeacher` TeacherService POST method for `sign-up` endpoint
- `TeacherSignUp` calls `usePostCreateTeacher` hook successfully and handles inputed values to mount payload
- `TeacherSignUp.test.tsx` checks `TeacherSignUp`'s behaviors