### PR TITLE
dataflow to create an answer to a question as a teacher

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,12 +6,14 @@ import { DatabaseModule } from './infra/dataSource.module';
 import { AppController } from './app.controller';
 import { StudentModule } from './domain/src/student/studentModule';
 import { QuestionModule } from './domain/src/question/questionModule';
+import { AnswerModule } from './domain/src/answer/answerModule';
 
 @Module({
   imports: [
     StudentModule,
     TeacherModule,
     QuestionModule,
+    AnswerModule,
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', '../../ui', 'dist'),
       exclude: ['/api*'],

--- a/backend/src/domain/src/answer/answerController.ts
+++ b/backend/src/domain/src/answer/answerController.ts
@@ -1,59 +1,16 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Param,
-  Delete,
-  NotFoundException,
-} from '@nestjs/common';
+import { Controller, Post, Body, Param } from '@nestjs/common';
 import { AnswerService } from './answerService';
 import { CreateAnswerDto } from './dto/createAnswer';
-import { Answer } from './answer';
-import { UpdateAnswerDto } from './dto/updateAnswer';
 
 @Controller('answer')
 export class AnswerController {
   constructor(private readonly answerService: AnswerService) {}
 
-  @Post()
-  async create(@Body() createAnswerDto: CreateAnswerDto): Promise<Answer> {
-    return this.answerService.create(createAnswerDto);
-  }
-
-  @Get()
-  async findAll(): Promise<Answer[]> {
-    return this.answerService.findAll();
-  }
-
-  @Get(':id')
-  async findById(@Param('id') answerId: number): Promise<Answer> {
-    const answer = this.answerService.findById(answerId);
-    if (!answer) {
-      throw new NotFoundException('Answer not found');
-    }
-    return answer;
-  }
-
-  @Delete(':id')
-  async delete(@Param('id') answerId: number): Promise<void> {
-    this.answerService.delete(answerId);
-  }
-
-  async update(
-    answerId: number,
-    updateAnswerDto: UpdateAnswerDto,
-  ): Promise<Answer> {
-    const answer = this.findById(answerId);
-    if (!answer) {
-      throw new NotFoundException('Answer not found');
-    }
-    if (updateAnswerDto.description !== undefined) {
-      (await answer).setAnswerDescription = updateAnswerDto.description;
-    }
-    if (updateAnswerDto.answeringTo !== undefined) {
-      (await answer).answeringTo = updateAnswerDto.answeringTo;
-    }
-    return answer;
+  @Post('create/:teacherId')
+  async createAnswer(
+    @Param('teacherId') teacherId: number,
+    @Body() createAnswerDto: CreateAnswerDto,
+  ) {
+    return this.answerService.createAnswer(createAnswerDto, teacherId);
   }
 }

--- a/backend/src/domain/src/answer/answerModule.ts
+++ b/backend/src/domain/src/answer/answerModule.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { DatabaseModule } from '../../../infra/dataSource.module';
+import { Answer } from './Answer';
+import { AnswerService } from './answerService';
+import { answersProviders } from '../../../infra/persistence/providers/answer.provider';
+import { TeacherModule } from '../teacher/teacherModule';
+import { QuestionModule } from '../question/questionModule';
+
+@Module({
+  imports: [
+    Answer,
+    DatabaseModule,
+    forwardRef(() => TeacherModule),
+    forwardRef(() => QuestionModule),
+  ],
+  controllers: [],
+  providers: [...answersProviders, AnswerService],
+  exports: [...answersProviders, AnswerService],
+})
+export class AnswerModule {}

--- a/backend/src/domain/src/answer/answerService.ts
+++ b/backend/src/domain/src/answer/answerService.ts
@@ -1,35 +1,50 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { Answer } from './answer';
+import { Inject, Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { AnswerEntity } from '../../../infra/persistence/entities/AnswerEntity';
+import { QuestionEntity } from '../../../infra/persistence/entities/QuestionEntity';
 import { CreateAnswerDto } from './dto/createAnswer';
+import { TeacherEntity } from '../../../infra/persistence/entities/TeacherEntity';
+
 @Injectable()
 export class AnswerService {
-  private readonly answers: Answer[] = [];
+  constructor(
+    @Inject('ANSWER_REPOSITORY')
+    private readonly answerRepository: Repository<AnswerEntity>,
+    @Inject('QUESTION_REPOSITORY')
+    private readonly questionRepository: Repository<QuestionEntity>,
+    @Inject('TEACHER_REPOSITORY')
+    private readonly teacherRepository: Repository<TeacherEntity>,
+  ) {}
 
-  create(createAnswerDto: CreateAnswerDto): Answer {
-    const answer = new Answer(
-      createAnswerDto.answerId,
-      createAnswerDto.text,
-      createAnswerDto.answeringTo,
-    );
-    this.answers.push(answer);
-    return answer;
-  }
+  async createAnswer(
+    createAnswerDto: CreateAnswerDto,
+    teacherId: number,
+  ): Promise<AnswerEntity> {
+    const { text, answeringTo } = createAnswerDto;
 
-  findAll(): Answer[] {
-    return this.answers;
-  }
-
-  findById(answerId: number): Answer {
-    return this.answers.find((answer) => answer.getAnswerById === answerId);
-  }
-
-  delete(answerId: number): void {
-    const index = this.answers.findIndex(
-      (answer) => answer.getAnswerById === answerId,
-    );
-    if (index === -1) {
-      throw new NotFoundException('Answer not found');
+    const question = await this.questionRepository.findOne({
+      where: { questionId: answeringTo },
+    });
+    if (!question) {
+      throw new Error('Question not found');
     }
-    this.answers.splice(index, 1);
+
+    const teacher = await this.teacherRepository.findOne({
+      where: { teacherId },
+    });
+    if (!teacher) {
+      throw new Error('Teacher not found');
+    }
+
+    question.answeredBy = teacher;
+    await this.questionRepository.save(question);
+
+    const answer = this.answerRepository.create({
+      description: text,
+      answeringTo: question,
+      answeredBy: teacher,
+    });
+
+    return this.answerRepository.save(answer);
   }
 }

--- a/backend/src/domain/src/answer/answerService.ts
+++ b/backend/src/domain/src/answer/answerService.ts
@@ -20,10 +20,11 @@ export class AnswerService {
     createAnswerDto: CreateAnswerDto,
     teacherId: number,
   ): Promise<AnswerEntity> {
-    const { text, answeringTo } = createAnswerDto;
+    const { description, answeringTo } = createAnswerDto;
 
     const question = await this.questionRepository.findOne({
       where: { questionId: answeringTo },
+      relations: ['answersRelations'],
     });
     if (!question) {
       throw new Error('Question not found');
@@ -40,7 +41,7 @@ export class AnswerService {
     await this.questionRepository.save(question);
 
     const answer = this.answerRepository.create({
-      description: text,
+      description: description,
       answeringTo: question,
       answeredBy: teacher,
     });

--- a/backend/src/domain/src/answer/dto/createAnswer.ts
+++ b/backend/src/domain/src/answer/dto/createAnswer.ts
@@ -2,7 +2,7 @@ import { IsString } from 'class-validator';
 
 export class CreateAnswerDto {
   @IsString()
-  text: string;
+  description: string;
 
   answeringTo: number; //questionId
   answeredBy: number; //teacherId

--- a/backend/src/domain/src/answer/dto/createAnswer.ts
+++ b/backend/src/domain/src/answer/dto/createAnswer.ts
@@ -1,12 +1,9 @@
-import { IsString, IsUUID } from 'class-validator';
-import { Question } from '../../question/Question';
-export class CreateAnswerDto {
-  @IsUUID()
-  answerId: number;
+import { IsString } from 'class-validator';
 
+export class CreateAnswerDto {
   @IsString()
   text: string;
 
-  @IsUUID()
-  answeringTo: Question;
+  answeringTo: number; //questionId
+  answeredBy: number; //teacherId
 }

--- a/backend/src/domain/src/question/questionModule.ts
+++ b/backend/src/domain/src/question/questionModule.ts
@@ -9,6 +9,6 @@ import { StudentModule } from '../student/studentModule';
   imports: [Question, DatabaseModule, forwardRef(() => StudentModule)],
   controllers: [],
   providers: [...questionsProviders, QuestionService],
-  exports: [QuestionService],
+  exports: [...questionsProviders, QuestionService],
 })
 export class QuestionModule {}

--- a/backend/src/domain/src/teacher/Teacher.ts
+++ b/backend/src/domain/src/teacher/Teacher.ts
@@ -1,7 +1,7 @@
-import { Question } from '../question/Question';
 import { TeachingArea } from '../../../../../shared/enum';
 import { TeacherInterface, Credential } from '../../../../../shared/interfaces';
 import bcrypt from 'bcrypt';
+import { Answer } from '../answer/Answer';
 
 export class Teacher implements TeacherInterface {
   private readonly teacherId: number;
@@ -14,7 +14,7 @@ export class Teacher implements TeacherInterface {
     public credentials: Credential[],
     public teachingAreas: TeachingArea[],
     public score: number = 0,
-    public answeredQuestions: Question[] = [],
+    public answers: Answer[] = [],
   ) {
     this.password = password;
   }

--- a/backend/src/domain/src/teacher/dto/createTeacher.ts
+++ b/backend/src/domain/src/teacher/dto/createTeacher.ts
@@ -1,7 +1,7 @@
 import { IsEmail, IsNumber, IsString, IsStrongPassword } from 'class-validator';
-import { Question } from '../../question/Question';
 import { TeachingArea } from '../../../../../../shared/enum';
 import { Credential } from '../../../../../../shared/interfaces';
+import { Answer } from '../../answer/Answer';
 
 export class CreateTeacherDto {
   @IsString()
@@ -23,5 +23,5 @@ export class CreateTeacherDto {
   @IsNumber()
   score?: number = 0;
 
-  answeredQuestions?: Question[] = [];
+  answers: Answer[] = [];
 }

--- a/backend/src/domain/src/teacher/teacherController.ts
+++ b/backend/src/domain/src/teacher/teacherController.ts
@@ -3,14 +3,23 @@ import {
   Get,
   Post,
   Body,
+  Inject,
+  forwardRef,
   // NotFoundException,
 } from '@nestjs/common';
 import { CreateTeacherDto } from './dto';
 import { TeacherLoginDto } from './dto/loginTeacher';
 import { TeacherService } from './teacherService';
+import { CreateAnswerDto } from '../answer/dto/createAnswer';
+import { AnswerService } from '../answer/answerService';
+
 @Controller('teacher')
 export class TeacherController {
-  constructor(private readonly teacherService: TeacherService) {}
+  constructor(
+    private readonly teacherService: TeacherService,
+    @Inject(forwardRef(() => AnswerService))
+    private readonly answerService: AnswerService,
+  ) {}
 
   @Get('sign-up')
   getSignUp() {
@@ -38,9 +47,11 @@ export class TeacherController {
   async createTeacher(@Body() createTeacherDto: CreateTeacherDto) {
     return this.teacherService.create(createTeacherDto);
   }
-
-  // @Get()
-  // async findAll(): Promise<Teacher[]> {
-  //   return this.teacherService.findAll();
-  // }
+  @Post('answer')
+  async createAnswer(@Body() createAnswerDto: CreateAnswerDto) {
+    return this.answerService.createAnswer(
+      createAnswerDto,
+      createAnswerDto.answeredBy,
+    );
+  }
 }

--- a/backend/src/domain/src/teacher/teacherModule.ts
+++ b/backend/src/domain/src/teacher/teacherModule.ts
@@ -1,12 +1,14 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { Teacher } from './Teacher';
 import { TeacherController } from './teacherController';
 import { TeacherService } from './teacherService';
 import { DatabaseModule } from '../../../infra/dataSource.module';
 import { teacherProviders } from '../../../infra/persistence/providers/teacher.provider';
+import { AnswerModule } from '../answer/answerModule';
 @Module({
-  imports: [Teacher, DatabaseModule],
+  imports: [Teacher, DatabaseModule, forwardRef(() => AnswerModule)],
   controllers: [TeacherController],
   providers: [...teacherProviders, TeacherService],
+  exports: [...teacherProviders, TeacherService],
 })
 export class TeacherModule {}

--- a/backend/src/domain/src/teacher/teacherService.ts
+++ b/backend/src/domain/src/teacher/teacherService.ts
@@ -32,8 +32,12 @@ export class TeacherService {
     return this.teacherRepository.save(newTeacher);
   }
 
-  async findByEmail(email: string): Promise<TeacherEntity | undefined> {
+  async findByEmail(email: string): Promise<TeacherEntity | null> {
     return this.teacherRepository.findOne({ where: { email } });
+  }
+
+  async findById(teacherId: number): Promise<TeacherEntity | null> {
+    return this.teacherRepository.findOne({ where: { teacherId } });
   }
 
   async findByEmailAndPassword(

--- a/backend/src/infra/persistence/entities/AnswerEntity.ts
+++ b/backend/src/infra/persistence/entities/AnswerEntity.ts
@@ -1,5 +1,12 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { QuestionEntity } from './QuestionEntity';
+import { TeacherEntity } from './TeacherEntity';
 
 @Entity('answers')
 export class AnswerEntity {
@@ -9,8 +16,11 @@ export class AnswerEntity {
   @Column({ type: 'text' })
   description: string;
 
-  @ManyToOne(() => QuestionEntity, (question) => question.answers, {
-    onDelete: 'CASCADE',
-  })
+  @ManyToOne(() => QuestionEntity, (question) => question.answers)
+  @JoinColumn({ name: 'answeringTo' })
   answeringTo: QuestionEntity;
+
+  @ManyToOne(() => TeacherEntity, (teacher) => teacher.answers)
+  @JoinColumn({ name: 'answeredBy' })
+  answeredBy: TeacherEntity;
 }

--- a/backend/src/infra/persistence/entities/QuestionEntity.ts
+++ b/backend/src/infra/persistence/entities/QuestionEntity.ts
@@ -1,4 +1,5 @@
 import {
+  AfterLoad,
   Column,
   Entity,
   Index,
@@ -39,11 +40,20 @@ export class QuestionEntity {
   @OneToMany(() => AnswerEntity, (answer) => answer.answeringTo, {
     cascade: true,
   })
-  answers: AnswerEntity[];
+  answersRelations: AnswerEntity[];
 
   @ManyToOne(() => TeacherEntity, (teacher) => teacher.answers, {
     nullable: true,
   })
   @JoinColumn({ name: 'answeredBy' })
   answeredBy: TeacherEntity;
+
+  @Column({ type: 'jsonb', nullable: true })
+  answers: string[];
+
+  @AfterLoad()
+  async populateAnswers() {
+    this.answers =
+      this.answersRelations?.map((answer) => answer.description) || [];
+  }
 }

--- a/backend/src/infra/persistence/entities/QuestionEntity.ts
+++ b/backend/src/infra/persistence/entities/QuestionEntity.ts
@@ -41,7 +41,9 @@ export class QuestionEntity {
   })
   answers: AnswerEntity[];
 
-  @ManyToOne(() => TeacherEntity, (teacher) => teacher.answeredQuestions)
+  @ManyToOne(() => TeacherEntity, (teacher) => teacher.answers, {
+    nullable: true,
+  })
   @JoinColumn({ name: 'answeredBy' })
   answeredBy: TeacherEntity;
 }

--- a/backend/src/infra/persistence/entities/TeacherEntity.ts
+++ b/backend/src/infra/persistence/entities/TeacherEntity.ts
@@ -5,8 +5,8 @@ import {
   OneToMany,
   Index,
 } from 'typeorm';
-import { QuestionEntity } from './QuestionEntity';
 import { TeachingArea } from '../../../../../shared/enum';
+import { AnswerEntity } from './AnswerEntity';
 
 @Entity('teachers')
 @Index('idx_teacher_email', ['email'], { unique: true })
@@ -33,6 +33,6 @@ export class TeacherEntity {
   @Column({ default: 0 })
   score: number;
 
-  @OneToMany(() => QuestionEntity, (question) => question.answeredBy)
-  answeredQuestions: QuestionEntity[];
+  @OneToMany(() => AnswerEntity, (answer) => answer.answeredBy)
+  answers: AnswerEntity[];
 }

--- a/backend/src/infra/persistence/providers/answer.provider.ts
+++ b/backend/src/infra/persistence/providers/answer.provider.ts
@@ -1,0 +1,11 @@
+import { DataSource } from 'typeorm';
+import { AnswerEntity } from '../entities/AnswerEntity';
+
+export const answersProviders = [
+  {
+    provide: 'ANSWER_REPOSITORY',
+    useFactory: (dataSource: DataSource) =>
+      dataSource.getRepository(AnswerEntity),
+    inject: ['DATA_SOURCE'],
+  },
+];

--- a/shared/interfaces.ts
+++ b/shared/interfaces.ts
@@ -13,7 +13,7 @@ export interface TeacherInterface {
   credentials: Credential[];
   teachingAreas: TeachingArea[];
   score: number;
-  answeredQuestions?: Question[];
+  answers?: Answer[];
 }
 
 export interface StudentInterface {

--- a/shared/interfaces.ts
+++ b/shared/interfaces.ts
@@ -36,6 +36,13 @@ export interface QuestionInterface {
   answeredBy?: number;
 }
 
+export interface AnswerInterface {
+  answerId: number;
+  description: string;
+  answeringTo: number; //questionId
+  answeredBy: number; //teacherId
+}
+
 export interface Credential {
   id: string;
   name: string;

--- a/ui/src/components/helpers/interfaces.ts
+++ b/ui/src/components/helpers/interfaces.ts
@@ -40,8 +40,10 @@ interface Question {
 }
 
 interface Answer {
-  question: Question;
-  text: string
+  answerId: number;
+  description: string;
+  answeringTo: number; //questionId
+  answeredBy: number; //teacherId
 }
 
 export type { TeacherRegistry, StudentRegistry, Question, Answer };

--- a/ui/src/hooks/usePostCreateAnswer.ts
+++ b/ui/src/hooks/usePostCreateAnswer.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { createAnswer } from '../services/AnswerService';
+import { AnswerInterface } from '@shared/interfaces';
+
+/**
+ * Custom hook to create a question as a student.
+ * @param {object} options - Options for the mutation (e.g., onSuccess, onError).
+ */
+export const useCreateQuestion = (options = {}) => {
+  return useMutation<AnswerInterface, unknown, Partial<AnswerInterface>>({
+    mutationFn: (data) => createAnswer(data),
+    mutationKey: ['answer', 'create'],
+    ...options,
+  });
+};

--- a/ui/src/services/AnswerService.ts
+++ b/ui/src/services/AnswerService.ts
@@ -1,0 +1,12 @@
+import axiosInstance from '../config/axiosConfig';
+import { AnswerInterface } from '@shared/interfaces';
+
+/**
+ * Service to create a question.
+ * @param {Partial<AnswerInterface>} data - The question data to be created.
+ * @returns {Promise<AnswerInterface>} - The created question response.
+ */
+export const createAnswer = async (data: Partial<AnswerInterface>): Promise<AnswerInterface> => {
+  const response = await axiosInstance.post('/teacher/answer', data);
+  return response.data;
+};


### PR DESCRIPTION
Backend:
- Implements database relationship between `StudentEntity`, `QuestionEntity`, `TeacherEntity` and `AnswerEntity`.
- Implements `AnswerService` and it's providers
- Implements route + endpoint + service to create an answer as teacher
- New QuestionEntity column `answers: string[]` representing relationship between questions and answer's descriptions

Frontend:
Implements `AnswerService` with `createAnswer` method and `usePostCreateAnswer` hook calling it